### PR TITLE
Add registration endpoints

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -13,5 +13,9 @@
 	"please login again": "please login again",
 	"change success": "change success",
 	"Logout": "Logout",
-	"Register": "Register"
+        "Register": "Register",
+        "registered": "registered",
+        "email verified": "email verified",
+        "email sent": "email sent",
+        "password reset": "password reset"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -12,5 +12,9 @@
   "new password": "新密码",
   "please login again": "请重新登录",
   "change success": "修改成功",
-  "Logout": "登出"
+  "Logout": "登出",
+  "registered": "注册成功",
+  "email verified": "邮箱已验证",
+  "email sent": "邮件已发送",
+  "password reset": "密码已重置"
 }

--- a/sql/codepush-v0.6.0-patch.sql
+++ b/sql/codepush-v0.6.0-patch.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `users_v2` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `email` varchar(255) NOT NULL,
+  `password` varchar(255) NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `role` enum('admin','user') NOT NULL DEFAULT 'user',
+  `is_active` boolean NOT NULL DEFAULT true,
+  `email_verified` boolean NOT NULL DEFAULT false,
+  `verification_token` varchar(64),
+  `reset_password_token` varchar(64),
+  `reset_password_expires` timestamp NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+UPDATE `versions` SET `version` = '0.6.0' WHERE `type` = '1';

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { accessKeysRouter } from './routes/accessKeys';
 import { accountRouter } from './routes/account';
 import { appsRouter } from './routes/apps';
 import { authRouter } from './routes/auth';
+import { apiAuthRouter } from './routes/apiAuth';
 import { indexRouter } from './routes/index';
 import { indexV1Router } from './routes/indexV1';
 import { usersRouter } from './routes/users';
@@ -85,6 +86,7 @@ app.use('/v0.1/public/codepush', indexV1Router);
 app.use('/accessKeys', accessKeysRouter);
 app.use('/apps', appsRouter);
 app.use('/account', accountRouter);
+app.use('/api/auth', apiAuthRouter);
 // code-push-server routes
 app.use('/auth', authRouter);
 app.use('/users', usersRouter);

--- a/src/core/const.ts
+++ b/src/core/const.ts
@@ -32,4 +32,4 @@ export const RELEASE_METHOD_UPLOAD = 'Upload';
 
 export const DIFF_MANIFEST_FILE_NAME = 'hotcodepush.json';
 
-export const CURRENT_DB_VERSION = '0.5.0';
+export const CURRENT_DB_VERSION = '0.6.0';

--- a/src/core/services/email-manager.ts
+++ b/src/core/services/email-manager.ts
@@ -40,6 +40,22 @@ class EmailManager {
             html: `<div>您接收的验证码为: <em style="color:red;">${code}</em>  20分钟内有效</div>`,
         });
     }
+
+    sendVerifyEmail(email: string, token: string) {
+        return this.sendMail({
+            to: email,
+            subject: 'Verify your email',
+            html: `<div>Please verify your email using this token: <em>${token}</em></div>`,
+        });
+    }
+
+    sendResetPasswordMail(email: string, token: string) {
+        return this.sendMail({
+            to: email,
+            subject: 'Reset Password',
+            html: `<div>Reset your password using this token: <em>${token}</em></div>`,
+        });
+    }
 }
 
 export const emailManager = new EmailManager();

--- a/src/core/services/registration-service.ts
+++ b/src/core/services/registration-service.ts
@@ -1,0 +1,77 @@
+import _ from 'lodash';
+import moment from 'moment';
+import validator from 'validator';
+import { Logger } from 'kv-logger';
+import { AppError } from '../app-error';
+import { emailManager } from './email-manager';
+import { UsersV2 } from '../../models/users_v2';
+import { passwordHashSync, randToken } from '../utils/security';
+
+class RegistrationService {
+    validatePassword(password: string) {
+        const regex = /^(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
+        if (!regex.test(password)) {
+            throw new AppError('Password does not meet complexity requirements');
+        }
+    }
+
+    async register(email: string, password: string, name: string, logger: Logger) {
+        if (!validator.isEmail(email)) {
+            throw new AppError('Invalid email address');
+        }
+        this.validatePassword(password);
+        if (!name) {
+            throw new AppError('Invalid user name');
+        }
+        const exists = await UsersV2.findOne({ where: { email } });
+        if (exists) {
+            throw new AppError('Email already registered');
+        }
+        const verificationToken = randToken(32);
+        const user = await UsersV2.create({
+            email,
+            password: passwordHashSync(password),
+            name,
+            verification_token: verificationToken,
+        });
+        await emailManager.sendVerifyEmail(email, verificationToken);
+        logger.info('register new user', { email });
+        return user;
+    }
+
+    async verify(token: string) {
+        const user = await UsersV2.findOne({ where: { verification_token: token } });
+        if (!user) {
+            throw new AppError('Invalid verification token');
+        }
+        user.set('email_verified', true);
+        user.set('verification_token', null);
+        await user.save();
+    }
+
+    async forgotPassword(email: string) {
+        const user = await UsersV2.findOne({ where: { email } });
+        if (!user) {
+            throw new AppError('Email not found');
+        }
+        const token = randToken(32);
+        user.set('reset_password_token', token);
+        user.set('reset_password_expires', moment().add(1, 'day').toDate());
+        await user.save();
+        await emailManager.sendResetPasswordMail(email, token);
+    }
+
+    async resetPassword(token: string, password: string) {
+        this.validatePassword(password);
+        const user = await UsersV2.findOne({ where: { reset_password_token: token } });
+        if (!user || !user.reset_password_expires || moment().isAfter(user.reset_password_expires)) {
+            throw new AppError('Reset token invalid or expired');
+        }
+        user.set('password', passwordHashSync(password));
+        user.set('reset_password_token', null);
+        user.set('reset_password_expires', null);
+        await user.save();
+    }
+}
+
+export const registrationService = new RegistrationService();

--- a/src/models/users_v2.ts
+++ b/src/models/users_v2.ts
@@ -1,0 +1,76 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../core/utils/connections';
+
+export interface UsersV2Interface extends Model {
+    id: number;
+    email: string;
+    password: string;
+    name: string;
+    role: 'admin' | 'user';
+    is_active: boolean;
+    email_verified: boolean;
+    verification_token: string | null;
+    reset_password_token: string | null;
+    reset_password_expires: Date | null;
+    created_at: Date;
+    updated_at: Date;
+    deleted_at: Date | null;
+}
+
+export const UsersV2 = sequelize.define<UsersV2Interface>(
+    'UsersV2',
+    {
+        id: {
+            type: DataTypes.BIGINT.UNSIGNED,
+            allowNull: false,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        password: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        name: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+        },
+        role: {
+            type: DataTypes.ENUM('admin', 'user'),
+            allowNull: false,
+            defaultValue: 'user',
+        },
+        is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+        },
+        email_verified: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+        },
+        verification_token: DataTypes.STRING,
+        reset_password_token: DataTypes.STRING,
+        reset_password_expires: DataTypes.DATE,
+        created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+        },
+        updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+        },
+        deleted_at: DataTypes.DATE,
+    },
+    {
+        tableName: 'users_v2',
+        underscored: true,
+        paranoid: true,
+    },
+);

--- a/src/routes/apiAuth.ts
+++ b/src/routes/apiAuth.ts
@@ -1,0 +1,65 @@
+import express from 'express';
+import _ from 'lodash';
+import { Req } from '../core/middleware';
+import { AppError } from '../core/app-error';
+import { registrationService } from '../core/services/registration-service';
+
+export const apiAuthRouter = express.Router();
+
+apiAuthRouter.post('/register', async (req: Req<void, { email: string; password: string; name: string }, void>, res, next) => {
+    const { logger, body } = req;
+    try {
+        const user = await registrationService.register(
+            _.trim(body.email),
+            _.trim(body.password),
+            _.trim(body.name),
+            logger,
+        );
+        res.send({ success: true, message: 'registered', user: { id: user.id, email: user.email, name: user.name } });
+    } catch (e) {
+        if (e instanceof AppError) {
+            res.send({ success: false, message: e.message });
+        } else {
+            next(e);
+        }
+    }
+});
+
+apiAuthRouter.get('/verify/:token', async (req: Req<{ token: string }, void, void>, res, next) => {
+    try {
+        await registrationService.verify(req.params.token);
+        res.send({ success: true, message: 'email verified' });
+    } catch (e) {
+        if (e instanceof AppError) {
+            res.send({ success: false, message: e.message });
+        } else {
+            next(e);
+        }
+    }
+});
+
+apiAuthRouter.post('/forgot-password', async (req: Req<void, { email: string }, void>, res, next) => {
+    try {
+        await registrationService.forgotPassword(_.trim(req.body.email));
+        res.send({ success: true, message: 'email sent' });
+    } catch (e) {
+        if (e instanceof AppError) {
+            res.send({ success: false, message: e.message });
+        } else {
+            next(e);
+        }
+    }
+});
+
+apiAuthRouter.post('/reset-password', async (req: Req<void, { token: string; password: string }, void>, res, next) => {
+    try {
+        await registrationService.resetPassword(_.trim(req.body.token), _.trim(req.body.password));
+        res.send({ success: true, message: 'password reset' });
+    } catch (e) {
+        if (e instanceof AppError) {
+            res.send({ success: false, message: e.message });
+        } else {
+            next(e);
+        }
+    }
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -144,6 +144,6 @@ indexRouter.post(
     },
 );
 
-indexRouter.get('/authenticated', checkToken, (req, res) => {
-    return res.send({ authenticated: true });
+indexRouter.get('/authenticated', checkToken, (req: Req, res) => {
+    res.send({ authenticated: true });
 });

--- a/tests/api/register/register.test.js
+++ b/tests/api/register/register.test.js
@@ -1,0 +1,17 @@
+const { app } = require('../../../bin/app');
+const request = require('supertest')(app);
+const should = require('should');
+
+describe('api/register/register.test.js', function () {
+    it('should register user', function (done) {
+        request
+            .post('/api/auth/register')
+            .send({ email: 'test@example.com', password: 'Password1!', name: 'test' })
+            .end(function (err, res) {
+                should.not.exist(err);
+                const rs = JSON.parse(res.text);
+                rs.should.have.property('success', true);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
## Summary
- bump DB version
- create users_v2 table
- support email verification
- implement registration service and routes
- translate registration messages
- add registration test stub

## Testing
- `npm run build`
- `npm test` *(fails: Can't add new command when connection is in closed state)*

------
https://chatgpt.com/codex/tasks/task_e_6849d94dcb448323ac8512ce9b3f854d